### PR TITLE
fix: disable the configured message in stopHook

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -148,7 +148,10 @@ void Task::errorHook()
 void Task::stopHook()
 {
     Driver* driver = static_cast<Driver*>(mDriver);
-    driver->writePeriodicPacketConfiguration("e2", 0);
+    driver->writePeriodicPacketConfiguration(
+        _configuration.get().period_message, 0
+    );
+
     TaskBase::stopHook();
 }
 void Task::cleanupHook()


### PR DESCRIPTION
We were always disabling E2, which would do nothing if it is not
the message in use.