### PR TITLE
feat: implement a box filter for the angular velocities (on top of #7)

### DIFF
--- a/imu_aceinna_openimu.orogen
+++ b/imu_aceinna_openimu.orogen
@@ -31,6 +31,15 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # UTM parameters for conversion from lat/lon/alt to local cartesian
     property "utm_parameters", "gps_base/UTMConversionParameters"
 
+    # The size (in samples) of the box filter we run over the angular velocity samples
+    #
+    # Some OpenIMU firmwares actually were not doing a low-pass filter on the
+    # gyros. This leads to a rather noisy angular velocity output, with a high
+    # frequency noise that this filter removes
+    #
+    # The default is to not filter at all
+    property "angular_velocity_filter_size", "int", 1
+
     output_port "pose_samples", "base/samples/RigidBodyState"
     output_port "acceleration_samples", "base/samples/RigidBodyAcceleration"
     output_port "imu_sensors_samples", "base/samples/IMUSensors"

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -44,6 +44,10 @@ namespace imu_aceinna_openimu {
             base::Time sample_time);
         aggregator::TimestampEstimator* mTimestampEstimator = nullptr;
 
+        int m_angular_velocity_filter_position = 0;
+        std::vector<base::Vector3d> m_angular_velocity_filter_buffer;
+        Eigen::Vector3d filterAngularVelocity(Eigen::Vector3d const& v);
+
     public:
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it


### PR DESCRIPTION
# What is this PR for

Some OpenIMU firmwares actually were not doing a low-pass filter on the
gyros. This leads to a rather noisy angular velocity output, with a high
frequency noise that this filter removes

# How I did it

Box filter.

# Results, How I tested

Not tested, will have to be tested in live. This is why the default setting (1) bypasses the filter altogether.

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
