### PR TITLE
feat: allow configuring the IMU magnetic distortion compensation from the component

### DIFF
--- a/imu_aceinna_openimu.orogen
+++ b/imu_aceinna_openimu.orogen
@@ -2,6 +2,8 @@
 
 name "imu_aceinna_openimu"
 
+cxx_standard "c++17"
+
 import_types_from "std"
 import_types_from "base"
 import_types_from "iodrivers_base"
@@ -14,6 +16,7 @@ import_types_from "imu_aceinna_openimuTypes.hpp"
 import_types_from "imu_aceinna_openimu/Configuration.hpp"
 import_types_from "imu_aceinna_openimu/FilterState.hpp"
 import_types_from "imu_aceinna_openimu/MagneticInfo.hpp"
+import_types_from "imu_aceinna_openimu/MagneticCalibration.hpp"
 import_types_from "imu_aceinna_openimu/Status.hpp"
 
 task_context "Task", subclasses: "iodrivers_base::Task" do
@@ -22,6 +25,7 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     property "local_time_synchronized_with_gps", "bool", false
     property "timestamp_estimator_status_period", "base/Time"
     property "configuration", "imu_aceinna_openimu/TaskConfiguration"
+    property "magnetic_calibration", "imu_aceinna_openimu/MagneticCalibration"
 
     # Message rate (in Hz)
     #


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-imu_aceinna_openimu/pull/18

The main issue was that the IMU needs to be reset for the setting to take effect.

This will make magnetic distortion calibration a lot easier, since we don't have to find a way to stop Syskit from
using the IMU at all - quite a feat.

The next step is to make a script that gathers data from the component directly instead of having to use the
log files.

Tested on the IMU from motion-box-v2 via UDP