### PR TITLE
fix: loop using a const reference instead of by value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/*
 
 *autobuild-stamp
 
+.cache/
+.vscode/c_cpp_properties.json

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -195,7 +195,7 @@ Eigen::Vector3d Task::filterAngularVelocity(Eigen::Vector3d const& angular_veloc
         angular_velocity;
 
     Eigen::Vector3d sum = Eigen::Vector3d::Zero();
-    for (auto const v : m_angular_velocity_filter_buffer) {
+    for (auto const& v : m_angular_velocity_filter_buffer) {
         sum += v;
     }
     return sum / filter_size;


### PR DESCRIPTION
As recommended by a gcc warning
